### PR TITLE
Fix (some, few) warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,20 +9,15 @@ env:
   - TRAVIS_BUILD_TYPE=Debug, TRAVIS_CMAKE_GENERATOR="Unix Makefiles", CMAKE_PREFIX_PATH="/home/travis/build/robotology-playground/codyco-superbuild/build/install"
   - TRAVIS_BUILD_TYPE=Release, TRAVIS_CMAKE_GENERATOR="Unix Makefiles", CMAKE_PREFIX_PATH="/home/travis/build/robotology-playground/codyco-superbuild/build/install"
 
-install:
-  - sudo sh -c 'echo "deb http://www.icub.org/ubuntu precise contrib/science" > /etc/apt/sources.list.d/icub.list'
-  - sudo add-apt-repository -y ppa:kalakris/cmake
-  - sudo apt-get update
-  - sudo apt-get install -qq libeigen3-dev libboost-system-dev libboost-thread-dev libboost-test-dev
-  - sudo apt-get --force-yes install icub-common
-  - sudo apt-get install cmake
-
 before_script:
   - cmake --version
   - cd ..
   # use superbuild for getting iDynTree dependencies 
   - git clone https://github.com/robotology/codyco-superbuild
   - cd codyco-superbuild
+  # install dependencies using the codyco-superbuild script
+  - chmod +x ./.ci/travis-deps.sh
+  - sh .ci/travis-deps.sh
   - mkdir build
   - cd build
   # using the YCM_EP_MAINTAINER_MODE variable to enable the subproject-dependees target 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,23 +68,23 @@ add_install_rpath_support(BIN_DIRS "${CMAKE_INSTALL_PREFIX}/bin"
                           DEPENDS IDYNTREE_ENABLE_RPATH
                           USE_LINK_PATH)
 
-message("Add library idyntree " ${LIB_TIPE}  ${folder_source} ${folder_header})
 add_library(idyntree ${LIB_TYPE} ${folder_source} ${folder_header})
 
 set_target_properties(idyntree PROPERTIES VERSION ${${VARS_PREFIX}_VERSION}
                                            SOVERSION ${${VARS_PREFIX}_VERSION}
                                            PUBLIC_HEADER "${folder_header}")
 
-message("kdl_codyco_INCLUDE_DIRS = ${kdl_codyco_INCLUDE_DIRS}")
 target_include_directories(idyntree PUBLIC "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>"
-                                           "$<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${${VARS_PREFIX}_INSTALL_INCLUDEDIR}>"
-                                            ${skinDynLib_INCLUDE_DIRS}
-                                            ${iDyn_INCLUDE_DIRS}
-                                            ${GSL_INCLUDE_DIRS}
-                                            ${YARP_INCLUDE_DIRS}
-                                            ${kdl_codyco_INCLUDE_DIRS}
-                                            ${Eigen3_INCLUDE_DIR}
-                                            ${kdl_format_io_INCLUDE_DIRS})
+                                           "$<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${${VARS_PREFIX}_INSTALL_INCLUDEDIR}>")
+
+target_include_directories(idyntree SYSTEM PUBLIC
+                                    ${skinDynLib_INCLUDE_DIRS}
+                                    ${iDyn_INCLUDE_DIRS}
+                                    ${GSL_INCLUDE_DIRS}
+                                    ${YARP_INCLUDE_DIRS}
+                                    ${kdl_codyco_INCLUDE_DIRS}
+                                    ${Eigen3_INCLUDE_DIR}
+                                    ${kdl_format_io_INCLUDE_DIRS})
 
 target_link_libraries(idyntree LINK_PUBLIC  skinDynLib iKin iDyn
                                             ${GSL_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,14 +77,25 @@ set_target_properties(idyntree PROPERTIES VERSION ${${VARS_PREFIX}_VERSION}
 target_include_directories(idyntree PUBLIC "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>"
                                            "$<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${${VARS_PREFIX}_INSTALL_INCLUDEDIR}>")
 
-target_include_directories(idyntree SYSTEM PUBLIC
-                                    ${skinDynLib_INCLUDE_DIRS}
-                                    ${iDyn_INCLUDE_DIRS}
-                                    ${GSL_INCLUDE_DIRS}
-                                    ${YARP_INCLUDE_DIRS}
-                                    ${kdl_codyco_INCLUDE_DIRS}
-                                    ${Eigen3_INCLUDE_DIR}
-                                    ${kdl_format_io_INCLUDE_DIRS})
+if (CMAKE_VERSION VERSION_GREATER 2.8.12)
+   target_include_directories(idyntree SYSTEM PUBLIC
+                                       ${skinDynLib_INCLUDE_DIRS}
+                                       ${iDyn_INCLUDE_DIRS}
+                                       ${GSL_INCLUDE_DIRS}
+                                       ${YARP_INCLUDE_DIRS}
+                                       ${kdl_codyco_INCLUDE_DIRS}
+                                       ${Eigen3_INCLUDE_DIR}
+                                       ${kdl_format_io_INCLUDE_DIRS})
+else()
+   target_include_directories(idyntree PUBLIC
+                                       ${skinDynLib_INCLUDE_DIRS}
+                                       ${iDyn_INCLUDE_DIRS}
+                                       ${GSL_INCLUDE_DIRS}
+                                       ${YARP_INCLUDE_DIRS}
+                                       ${kdl_codyco_INCLUDE_DIRS}
+                                       ${Eigen3_INCLUDE_DIR}
+                                       ${kdl_format_io_INCLUDE_DIRS})
+endif()
 
 target_link_libraries(idyntree LINK_PUBLIC  skinDynLib iKin iDyn
                                             ${GSL_LIBRARIES}

--- a/include/iCub/iDynTree/DynTree.h
+++ b/include/iCub/iDynTree/DynTree.h
@@ -91,6 +91,7 @@
 #include <kdl/tree.hpp>
 
 #include <iostream>
+#include <vector>
 #include <map>
 
 
@@ -152,10 +153,10 @@ class DynTree  {
         KDL::CoDyCo::TreePartition partition; /**< TreePartition object explicit present as it is conventient to encode/decode dynContact objects */
 
         //Violating DRY principle, but for code clarity
-        int NrOfDOFs;
-        int NrOfLinks;
-        int NrOfFTSensors;
-        int NrOfDynamicSubGraphs;
+        unsigned NrOfDOFs;
+        unsigned NrOfLinks;
+        unsigned NrOfFTSensors;
+        unsigned NrOfDynamicSubGraphs;
 
         //state of the robot
         KDL::Frame world_base_frame; /**< the position of the floating base frame with respect to the world reference frame \f$ {}^w H_b \f$ */
@@ -175,7 +176,7 @@ class DynTree  {
         //joint torque limits
         KDL::JntArray tau_max;
 
-        int constrained_count; /**< the number of DOFs that are constrained */
+        unsigned constrained_count; /**< the number of DOFs that are constrained */
 
         double setAng(const double q, const int i);
 
@@ -322,7 +323,6 @@ class DynTree  {
          *        be considered as FT sensors
          * @param imu_link_name name of the link considered the IMU sensor
          * @param serialization (optional) an explicit serialization of tree links and DOFs
-         * @param partition (optional) a partition of the tree (division of the links and DOFs in non-overlapping sets)
          *
          */
         DynTree(const KDL::Tree & _tree,
@@ -338,7 +338,6 @@ class DynTree  {
          *        be considered as FT sensors
          * @param imu_link_name name of the link considered the IMU sensor
          * @param serialization (optional) an explicit serialization of tree links and DOFs
-         * @param partition (optional) a partition of the tree (division of the links and DOFs in non-overlapping sets)
          *
          */
         DynTree(const std::string urdf_file,
@@ -510,7 +509,6 @@ class DynTree  {
         * Set joint positions in the specified part (if no part
         * is specified, set the joint positions of all the tree)
         * @param _q vector of joints position
-        * @param part_name optional: the name of the part of joint to set
         * @return the effective joint positions, considering min/max values
         */
         virtual yarp::sig::Vector setAng(const yarp::sig::Vector & _q) ;
@@ -521,7 +519,6 @@ class DynTree  {
         /**
         * Get joint positions in the specified part (if no part
         * is specified, get the joint positions of all the tree)
-        * @param part_name optional: the name of the part of joints to set
         * @return vector of joint positions
         */
         virtual yarp::sig::Vector getAng() const;
@@ -534,7 +531,6 @@ class DynTree  {
         * Set joint speeds in the specified part (if no part
         * is specified, set the joint speeds of all the tree)
         * @param _q vector of joint speeds
-        * @param part_name optional: the name of the part of joints to set
         * @return the effective joint speeds, considering min/max values
         */
         virtual yarp::sig::Vector setDAng(const yarp::sig::Vector & _q);
@@ -542,7 +538,6 @@ class DynTree  {
         /**
         * Get joint speeds in the specified part (if no part
         * is specified, get the joint speeds of all the tree)
-        * @param part_name optional: the name of the part of joints to get
         * @return vector of joint speeds
         *
         * \note please note that this does returns a vector of size getNrOfDOFs()
@@ -553,7 +548,6 @@ class DynTree  {
         * Set joint accelerations in the specified part (if no part
         * is specified, set the joint accelerations of all the tree)
         * @param _q vector of joint speeds
-        * @param part_name optional: the name of the part of joints to set
         * @return the effective joint accelerations, considering min/max values
         */
         virtual yarp::sig::Vector setD2Ang(const yarp::sig::Vector & _q);
@@ -561,7 +555,6 @@ class DynTree  {
         /**
         * Get joint speeds in the specified part (if no part
         * is specified, get the joint speeds of all the tree)
-        * @param part_name optional: the name of the part of joints to get
         * @return vector of joint accelerations
         */
         virtual yarp::sig::Vector getD2Ang() const;
@@ -829,7 +822,6 @@ class DynTree  {
         /**
         * Get joint torques in the specified part (if no part
         * is specified, get the joint torques of all the tree)
-        * @param part_name optional: the name of the part of joints to get
         * @return vector of joint torques
         */
         virtual yarp::sig::Vector getTorques() const;
@@ -964,7 +956,6 @@ class DynTree  {
         * is specified, get the Jacobian of the COM of all the tree) expressed in
         * the world frame
         * @param jac the output jacobiam matrix
-        * @param part_name optional: the name of the part of joints to get
         * @return true if succeeds, false otherwise
         */
         virtual bool getCOMJacobian(yarp::sig::Matrix & jac);

--- a/include/iCub/iDynTree/TorqueEstimationTree.h
+++ b/include/iCub/iDynTree/TorqueEstimationTree.h
@@ -31,8 +31,11 @@ class TorqueEstimationTree : public DynTree
      * Constructor for TorqueEstimationTree
      *
      *
-     * @param urdf_filename
-     * @param verbose
+     * @param urdf_filename urdf filename
+     * @param dof_serialization dof serialization. Default empty vector
+     * @param ft_serialization force torque serialization. Default empty vector
+     * @param fixed_link name of the fixed link. Default empty string
+     * @param verbose verbosity level. Default 0
      */
     TorqueEstimationTree(std::string urdf_filename,
                          std::vector<std::string> dof_serialization=std::vector<std::string>(0),

--- a/include/iCub/iDynTree/iDyn2KDL.h
+++ b/include/iCub/iDynTree/iDyn2KDL.h
@@ -7,27 +7,32 @@
 #ifndef IDYN2KDL_H
 #define IDYN2KDL_H
 
-#include <iCub/iDyn/iDyn.h>
-#include <yarp/os/all.h>
-#include <yarp/dev/all.h>
-#include <yarp/sig/all.h>
-#include <yarp/math/Math.h>
-#include <yarp/math/api.h>
-
-#include <iCub/ctrl/math.h>
-#include <iCub/ctrl/adaptWinPolyEstimator.h>
-#include <iCub/iDyn/iDynInv.h>
-#include <iCub/iDyn/iDynBody.h>
-#include <iCub/skinDynLib/skinContactList.h>
-
-#include <kdl/chain.hpp>
-#include <kdl/frames.hpp>
-#include <kdl/frames_io.hpp>
-#include <kdl/kinfam_io.hpp>
-
+#include <vector>
+#include <string>
 #include <cassert>
 
-using namespace yarp::math;
+namespace iCub {
+    namespace iDyn {
+        class iDynChain;
+        class iDynInvSensor;
+    }
+}
+
+namespace KDL {
+    class Chain;
+    class RigidBodyInertia;
+    class RotationalInertia;
+    class Frame;
+    class Rotation;
+    class Vector;
+}
+
+namespace yarp {
+    namespace sig {
+        class Vector;
+        class Matrix;
+    }
+}
 
 /**
  * Convert an iCub::iDyn::iDynChain object to a KDL::Chain object
@@ -125,7 +130,7 @@ void printKDLchain(std::string s,const KDL::Chain & kldChain);
  * @return true if conversion was successful, false otherwise
  * 
  */ 
-bool addBaseTransformation(const KDL::Chain & old_chain, KDL::Chain & new_chain, KDL::Frame H_new_old);
+bool addBaseTransformation(const KDL::Chain & old_chain, KDL::Chain & new_chain, KDL::Frame& H_new_old);
 
 /**
 *

--- a/include/iCub/iDynTree/idyn2kdl_icub.h
+++ b/include/iCub/iDynTree/idyn2kdl_icub.h
@@ -10,6 +10,7 @@
 #include <iCub/iDyn/iDyn.h>
 #include <iCub/iDyn/iDynBody.h>
 #include <kdl/tree.hpp>
+
 #include "iCub/iDynTree/iDyn2KDL.h"
 #include "iCub/iDynTree/TorqueEstimationTree.h"
 

--- a/include/iCub/iDynTree/yarp_kdl.h
+++ b/include/iCub/iDynTree/yarp_kdl.h
@@ -113,6 +113,12 @@ yarp::sig::Vector KDLtoYarp(const KDL::Vector & kdlVector);
 bool KDLtoYarp(const KDL::JntArray & kdlJntArray,yarp::sig::Vector & yarpVector);
 
 /**
+* Convert a KDL::Rotation to a yarp::sig::Matrix
+* @return true if conversion was successful, false otherwise
+*/
+bool KDLtoYarp(const KDL::Rotation & kdlRotation, yarp::sig::Matrix & yarpMatrix3_3);
+
+/**
  * Convert a KDL::Frame in a 4x4 rototranslation yarp::sig::Matrix 
  * @return true if conversion was successful, false otherwise
  */

--- a/src/DynTree.cpp
+++ b/src/DynTree.cpp
@@ -83,10 +83,10 @@ void DynTree::constructor(const KDL::Tree & _tree,
                           const std::vector<std::string> & joint_sensor_names,
                           const std::string & imu_link_name,
                           KDL::CoDyCo::TreeSerialization serialization,
-                          std::vector<KDL::Frame> child_sensor_transforms
+                          std::vector<KDL::Frame> /*child_sensor_transforms*/
 )
 {
-int ret;
+    int ret;
 
     undirected_tree = KDL::CoDyCo::UndirectedTree(_tree,serialization);
 
@@ -100,7 +100,7 @@ int ret;
     NrOfFTSensors = joint_sensor_names.size();
     NrOfDynamicSubGraphs = NrOfFTSensors + 1;
 
-    assert((int)undirected_tree.getNrOfDOFs() == NrOfDOFs);
+    assert(undirected_tree.getNrOfDOFs() == NrOfDOFs);
     //Remve assertion for robot without a proper fixed base
     //assert((int)undirected_tree.getNrOfLinks() == NrOfLinks);
 
@@ -172,7 +172,7 @@ int ret;
     correctly_configure = true;
 }
 
-DynTree::~DynTree() { } ;
+DynTree::~DynTree() { }
 
 double DynTree::setAng(const double q_in, const int i)
 {
@@ -213,7 +213,7 @@ int DynTree::buildSubGraphStructure(const std::vector<std::string> & ft_names)
 
     int next_id = 0;
 
-    for(int i=0; i < (int)dynamic_traversal.getNrOfVisitedLinks(); i++) {
+    for(int i=0; i < dynamic_traversal.getNrOfVisitedLinks(); i++) {
 
         KDL::CoDyCo::LinkMap::const_iterator link_it = dynamic_traversal.getOrderedLink(i);
         int link_nmbr = link_it->getLinkIndex();
@@ -292,9 +292,9 @@ int DynTree::getLinkFromSkinDynLibID(int body_part, int link)
 
 void DynTree::buildAb_contacts()
 {
-    #ifndef NDEBUG
-    bool extreme_verbose = false;
-    #endif
+//    #ifndef NDEBUG
+//    bool extreme_verbose = false;
+//    #endif
     //First calculate the known terms b related to inertial, gravitational and
     //measured F/T
 
@@ -805,11 +805,11 @@ void DynTree::setAllConstraints(bool _constrained)
 {
     if( _constrained ) {
         //all joints are now not constrained
-        for(int i=0; i < (int)constrained.size(); i++ ) constrained[i] = false;
+        for(size_t i=0; i < constrained.size(); i++ ) constrained[i] = false;
         constrained_count = 0;
     } else {
         //all joints are now constrained
-        for(int i=0; i < (int)constrained.size(); i++ ) constrained[i] = true;
+        for(size_t i=0; i < constrained.size(); i++ ) constrained[i] = true;
         constrained_count = constrained.size();
     }
 }
@@ -1181,27 +1181,27 @@ void pseudoInverse(const Eigen::Matrix<double, 6, 6+6>& A,
                                                         double tol,
                                                          Eigen::Matrix<double, 6+6, 6>& Apinv)
 {
-            using namespace Eigen;
+    using namespace Eigen;
 
-            int m = A.rows(), n = A.cols(), k = m < n ? m : n;
-            Eigen::JacobiSVD< Eigen::Matrix<double, 6, 6+6> > svd(A,Eigen::ComputeFullU|Eigen::ComputeFullV);
-            const JacobiSVD< Eigen::Matrix<double, 6, 6+6> >::SingularValuesType& singularValues = svd.singularValues();
-            Eigen::Matrix<double, 12, 6> invSinValues;
-            invSinValues.setZero();
-            for (int idx = 0; idx < singularValues.size(); idx++)
-            {
-                if( idx < singularValues.size() )
-                {
-                    invSinValues(idx,idx) = tol > 0 && singularValues(idx) > tol ? 1.0 / singularValues(idx) : 0.0;
-                }
-            }
-            //std::cout << "singularValues: " << singularValues << std::endl;
-            //std::cout << "invSinValues : " << invSinValues << std::endl;
-            Eigen::Matrix<double, 12, 12> V = svd.matrixV();
-            Eigen::Matrix<double, 6, 6> U = svd.matrixU();
-            //std::cout << "V " << V << std::endl;
-            //std::cout << "U " << U << std::endl;
-            Apinv =  V * invSinValues * U.transpose(); // damped pseudoinverse
+//    int m = A.rows(), n = A.cols(), k = m < n ? m : n;
+    Eigen::JacobiSVD< Eigen::Matrix<double, 6, 6+6> > svd(A,Eigen::ComputeFullU|Eigen::ComputeFullV);
+    const JacobiSVD< Eigen::Matrix<double, 6, 6+6> >::SingularValuesType& singularValues = svd.singularValues();
+    Eigen::Matrix<double, 12, 6> invSinValues;
+    invSinValues.setZero();
+    for (int idx = 0; idx < singularValues.size(); idx++)
+    {
+        if( idx < singularValues.size() )
+        {
+            invSinValues(idx,idx) = tol > 0 && singularValues(idx) > tol ? 1.0 / singularValues(idx) : 0.0;
+        }
+    }
+    //std::cout << "singularValues: " << singularValues << std::endl;
+    //std::cout << "invSinValues : " << invSinValues << std::endl;
+    Eigen::Matrix<double, 12, 12> V = svd.matrixV();
+    Eigen::Matrix<double, 6, 6> U = svd.matrixU();
+    //std::cout << "V " << V << std::endl;
+    //std::cout << "U " << U << std::endl;
+    Apinv =  V * invSinValues * U.transpose(); // damped pseudoinverse
 }
 
 bool DynTree::estimateDoubleSupportContactForce(int left_foot_id, int right_foot_id)
@@ -1323,7 +1323,7 @@ bool DynTree::dynamicRNEA()
 ////// COM related methods
 ////////////////////////////////////////////////////////////////////////
 
-KDL::Vector DynTree::getCOMKDL(const std::string part_name, int link_index)
+KDL::Vector DynTree::getCOMKDL(const std::string /*part_name*/, int link_index)
 {
     if( (link_index < 0 || link_index >= (int)undirected_tree.getNrOfLinks()) && link_index != -1 )
     {
@@ -2075,7 +2075,7 @@ bool DynTree::getJunctionName(const int junction_index, std::string & junction_n
 }
 
 // \todo TODO FIXME implement this method
-bool DynTree::getFTSensorName(const int junction_index, std::string & junction_name)
+bool DynTree::getFTSensorName(const int /*junction_index*/, std::string & /*junction_name*/)
 {
     return false;
 }
@@ -2100,7 +2100,7 @@ int DynTree::getIMUIndex(const std::string & imu_name)
 }
 
 // \todo TODO FIXME implement this method
-bool DynTree::getIMUName(const int junction_index, std::string & junction_name)
+bool DynTree::getIMUName(const int /*junction_index*/, std::string & /*junction_name*/)
 {
     return false;
 }

--- a/src/TorqueEstimationTree.cpp
+++ b/src/TorqueEstimationTree.cpp
@@ -15,6 +15,8 @@
 #include <kdl_format_io/urdf_import.hpp>
 #include <kdl_format_io/urdf_sensor_import.hpp>
 
+#include <yarp/os/Log.h>
+
 #include <vector>
 
 namespace iCub {
@@ -24,7 +26,8 @@ namespace iDynTree {
 TorqueEstimationTree::TorqueEstimationTree(std::string urdf_filename,
                                            std::vector<std::string> dof_serialization,
                                            std::vector<std::string> ft_serialization,
-                                           std::string fixed_link, unsigned int verbose)
+                                           std::string fixed_link,
+                                           unsigned int /*verbose*/)
 {
     yarp::sig::Vector q_min_yarp, q_max_yarp;
 
@@ -56,7 +59,7 @@ TorqueEstimationTree::TorqueEstimationTree(std::string urdf_filename,
     std::vector<KDL::Frame> child_sensor_transforms(ft_serialization.size());
     KDL::Frame kdlFrame;
 
-    for(int serialization_id=0; serialization_id < ft_serialization.size(); serialization_id++)
+    for(std::size_t serialization_id=0; serialization_id < ft_serialization.size(); serialization_id++)
     {
         if( 0 == ft_sensors.size() )
         {
@@ -64,10 +67,10 @@ TorqueEstimationTree::TorqueEstimationTree(std::string urdf_filename,
                 assert(false);
                 return;
         }
-        for(int ft_sens=0; ft_sens < ft_sensors.size(); ft_sens++ )
+        for(std::size_t ft_sens=0; ft_sens < ft_sensors.size(); ft_sens++ )
         {
             std::string ft_sens_name = ft_sensors[ft_sens].reference_joint;
-            int ft_sens_id;
+            std::size_t ft_sens_id;
 
             std::cout << "ft_sens" << ft_sens << std::endl;
 
@@ -111,19 +114,19 @@ TorqueEstimationTree::TorqueEstimationTree(std::string urdf_filename,
     if( dof_serialization.size() != 0 )
     {
         YARP_ASSERT(dof_serialization.size() == serial.getNrOfDOFs());
-        for(int dof=0; dof < dof_serialization.size(); dof++)
+        for(std::size_t dof=0; dof < dof_serialization.size(); dof++)
         {
             std::string dof_string = dof_serialization[dof];
             YARP_ASSERT(serial.getDOFID(dof_string) != -1);
             YARP_ASSERT(serial.getJunctionID(dof_string) != -1);
         }
 
-        for(int dof=0; dof < dof_serialization.size(); dof++)
+        for(std::size_t dof=0; dof < dof_serialization.size(); dof++)
         {
             std::string dof_string = dof_serialization[dof];
             std::cout << "[DEBUG] TorqueEstimationTree: Setting id of dof " << dof_string << " to " << dof << std::endl;
-            serial.setDOFNameID(dof_string,dof);
-            serial.setJunctionNameID(dof_string,dof);
+            serial.setDOFNameID(dof_string, (int)dof);
+            serial.setJunctionNameID(dof_string, (int)dof);
         }
     }
 
@@ -152,7 +155,7 @@ TorqueEstimationTree::TorqueEstimationTree(std::string urdf_filename,
     for(int dof = 0; dof < serial.getNrOfDOFs(); dof++ )
     {
         std::string dof_name = serial.getDOFName(dof);
-        for(int lim = 0; lim < joint_limits_names.size(); lim++ )
+        for(std::size_t lim = 0; lim < joint_limits_names.size(); lim++ )
         {
             if( joint_limits_names[lim] == dof_name )
             {

--- a/src/idyn2kdl_icub.cpp
+++ b/src/idyn2kdl_icub.cpp
@@ -6,6 +6,9 @@
 
 
 #include <iCub/iDynTree/idyn2kdl_icub.h>
+#include <yarp/math/Math.h>
+
+using yarp::math::cat;
 
 template<typename T, size_t N>
 T * end(T (&ra)[N]) {
@@ -29,7 +32,7 @@ bool names2links_joints(const std::vector<std::string> names,std::vector<std::st
 // For more informations on this values, check
 // https://github.com/robotology/codyco-modules/issues/49
 const double root_link_weight = 4.72;
-const double head_weight      = 3.0;
+//const double head_weight      = 3.0;
 
 KDL::RotationalInertia operator-(const KDL::RotationalInertia& Ia, const KDL::RotationalInertia& Ib){
     KDL::RotationalInertia result;
@@ -58,7 +61,7 @@ bool toKDL(const iCub::iDyn::iCubWholeBody & icub_idyn,
            iCub::iDynTree::iCubTree_serialization_tag serial,
            bool ft_foot,
            bool add_root_weight,
-           bool debug)
+           bool /*debug*/)
 {
     //sstd::cout << "toKDL(..) function called" << std::endl;
 
@@ -297,9 +300,8 @@ bool toKDL(const iCub::iDyn::iCubWholeBody & icub_idyn,
     q_min.resize(q_min_yarp.size());
     q_max.resize(q_max_yarp.size());
 
-    int jjj;
-    for(jjj=0; jjj<(int)q_min.rows(); jjj++) { q_min(jjj) = q_min_yarp(jjj); }
-    for(jjj=0; jjj<(int)q_max.rows(); jjj++) { q_max(jjj) = q_max_yarp(jjj); }
+    for(unsigned jjj=0; jjj<q_min.rows(); jjj++) { q_min(jjj) = q_min_yarp(jjj); }
+    for(unsigned jjj=0; jjj<q_max.rows(); jjj++) { q_max(jjj) = q_max_yarp(jjj); }
 
     //REP 120
 


### PR DESCRIPTION
In this patch I did the following things:
- split in the `CMakeLists.txt` the inclusion to be `SYSTEM` and not `SYSTEM`. This should help in cleaning compilers warnings.
- Cleaned up inclusions in `include/iCub/iDynTree/iDyn2KDL.h`. I did not removed redundant inclusions. Just moved them in the `cpp` and used forward declarations where possible.
- Tried some changes in unsigned vs signed variables. I tried to change the least. Hoping I did not change too much.
- Fixed some documentation warnings.